### PR TITLE
Ensure that lasso does not select hidden nodes

### DIFF
--- a/plugins/sigma.plugins.lasso/README.md
+++ b/plugins/sigma.plugins.lasso/README.md
@@ -8,7 +8,8 @@ Plugin developed by [Florent Schildknecht](https://github.com/Flo-Schield-Bobby)
 This plugin allows you to select several nodes with a lasso-tool:
 - Enable the lasso mode
 - Draw the lasso path
-- All the nodes with a center inside the path will then be available as an array, dispatched by an event.
+- All the nodes with a center inside the path will then be available as an array, dispatched by an event
+- Hidden nodes will not be selected
 - It currently works with a canvas renderer [not compatible with WebGL renderer]
 - Touch events are supported (it works on a mobile browser)
 

--- a/plugins/sigma.plugins.lasso/sigma.plugins.lasso.js
+++ b/plugins/sigma.plugins.lasso/sigma.plugins.lasso.js
@@ -293,7 +293,7 @@
             x = node[prefix + 'x'],
             y = node[prefix + 'y'];
 
-        if (this.drawingContext.isPointInPath(x, y)) {
+        if (this.drawingContext.isPointInPath(x, y) && !node.hidden) {
           this.selectedNodes.push(node);
         }
       }


### PR DESCRIPTION
A very simple edit to ensure that hidden nodes are not selected by the lasso. I believe that the lasso plugin is MIT licensed so hopefully there are no issues on that front but please let me know if that is not the case.

Edited to use plugin/lasso branch as requested.