### PR TITLE
Change initial type to integer in GEXF exporter 

### DIFF
--- a/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
+++ b/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
@@ -105,9 +105,9 @@
    * @return {string}      The updated variable type.
    */
   function typeOf(x, type) {
-    if (type === 'float' && typeof x === 'number') {
-      if (isInteger(x)) {
-        type = 'integer';
+    if (type === 'integer' && typeof x === 'number') {
+      if (!isInteger(x)) {
+        type = 'float';
       }
     }
     else if (typeof x !== 'number') {
@@ -223,7 +223,7 @@
             if (!(k in nodeAttrIndex)) {
               nodeAttrIndex[k] = {
                 id: nodeAttrCpt,
-                type: 'float'
+                type: 'integer'
               };
               nodeAttrCpt++;
             }
@@ -317,7 +317,7 @@
             if (!(k in edgeAttrIndex)) {
               edgeAttrIndex[k] = {
                 id: edgeAttrCpt,
-                type: 'float'
+                type: 'integer'
               };
               edgeAttrCpt++;
             }


### PR DESCRIPTION
I believe if an attribute has values such as:

```
var myAttibute = [0.34, 0.0, 0.25];
```

then the current gexf exporter will export with an attribute type of integer as the zero will return true for isInteger and the type will stick at integer.  Should we not do the reverse?  Start with the integer type and change to float type if a float is encountered with no reversion to integer type, i.e. set as float if at least one float is present.  

This pull request aims to reflect the above logic.  I may have missed something so please point out if so!