### PR TITLE
Fix browser tab crashing on attempt to download

### DIFF
--- a/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
+++ b/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
@@ -21,18 +21,28 @@
     // Anchor
     var anchor = document.createElement('a');
 
+    if(window.BlobBuilder){
+      // use Blob if available
+      var textFile = null,
+      makeTextFile = function (text) {
+        var data = new Blob([text], {type: 'text/plain'});
+        if (textFile !== null) {
+          window.URL.revokeObjectURL(textFile);
+        }
+        textFile = window.URL.createObjectURL(data);
+        return textFile;
+      };
 
-    var textFile = null,
-    makeTextFile = function (text) {
-      var data = new Blob([text], {type: 'text/plain'});
-      if (textFile !== null) {
-        window.URL.revokeObjectURL(textFile);
-      }
-      textFile = window.URL.createObjectURL(data);
-      return textFile;
-    };
+      anchor.setAttribute('href', makeTextFile(fileEntry));
+    }
+    else {
+      // else use dataURI
+      var dataUrl = 'data:text/xml;charset=UTF-8,' +
+            encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?>') +
+            encodeURIComponent(fileEntry);
+      anchor.setAttribute('href', dataUrl);
+    }
 
-    anchor.setAttribute('href', makeTextFile(fileEntry));
     anchor.setAttribute('download', filename || 'graph.' + extension);
 
     var event = document.createEvent('MouseEvent');

--- a/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
+++ b/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
@@ -21,7 +21,7 @@
     // Anchor
     var anchor = document.createElement('a');
 
-    if(window.BlobBuilder){
+    if(window.Blob){
       // use Blob if available
       var textFile = null,
       makeTextFile = function (text) {

--- a/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
+++ b/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
@@ -17,13 +17,24 @@
     throw 'sigma.exporters.gexf: sigma is not declared';
 
   // Utilities
-  function download(dataUrl, extension, filename) {
+  function download(fileEntry, extension, filename) {
     // Anchor
     var anchor = document.createElement('a');
-    anchor.setAttribute('href', dataUrl);
+
+
+    var textFile = null,
+    makeTextFile = function (text) {
+      var data = new Blob([text], {type: 'text/plain'});
+      if (textFile !== null) {
+        window.URL.revokeObjectURL(textFile);
+      }
+      textFile = window.URL.createObjectURL(data);
+      return textFile;
+    };
+
+    anchor.setAttribute('href', makeTextFile(fileEntry));
     anchor.setAttribute('download', filename || 'graph.' + extension);
 
-    // Click event
     var event = document.createEvent('MouseEvent');
     event.initMouseEvent('click', true, false, window, 0, 0, 0 ,0, 0,
       false, false, false, false, 0, null);
@@ -387,13 +398,8 @@
       sXML = oSerializer.serializeToString(doc);
 
       if (params.download) {
-        download(
-          'data:text/xml;charset=UTF-8,' +
-            encodeURIComponent('<?xml version="1.0" encoding="UTF-8"?>') +
-            encodeURIComponent(sXML),
-          'gexf',
-          params.filename
-        );
+
+        download(sXML, 'gexf', params.filename);
       }
 
       // Cleaning


### PR DESCRIPTION
I was trying to save my sigma instance as a `.gexf` file by using the `sigma.exporters.gexf` plugin. But, if my created file is quite large, say around 4MB, browser tab crashes.

I found the problem is in the download function, where the file is generated as a dataURI which would obviously be very big for a file of that size.

So I changed the download method to use a blob to create the file instead of dataURI, and that seems to work.