### PR TITLE
Fixes to plugin-louvain example

### DIFF
--- a/examples/plugin-louvain.html
+++ b/examples/plugin-louvain.html
@@ -217,14 +217,13 @@ s = new sigma({
 });
 
 // Layout the graph to see node clusters:
-var fa = sigma.layouts.configForceAtlas2(s, {
+var fa = s.configForceAtlas2({
   worker: true,
   autoStop: true,
   background: true,
   easing: 'cubicInOut'
 });
-sigma.layouts.startForceAtlas2();
-
+s.startForceAtlas2();
 
 var louvainInstance;
 
@@ -247,6 +246,9 @@ document.getElementById('run-btn').addEventListener("click", function(e) {
   s.refresh({skipIndexation: true});
 
   document.getElementById('nb-partitions').textContent = nbPartitions;
+
+  // Clear level selector first
+  document.getElementById('levels').innerHTML = '';
 
   // Fill level selector
   var levelElt = document.getElementById('levels');

--- a/examples/plugin-louvain.html
+++ b/examples/plugin-louvain.html
@@ -47,8 +47,8 @@
 <script src="../src/misc/sigma.misc.drawHovers.js"></script>
 <!-- END SIGMA IMPORTS -->
 <script src="../plugins/sigma.plugins.animate/sigma.plugins.animate.js"></script>
-<script src="../plugins/sigma.layout.forceAtlas2/worker.js"></script>
-<script src="../plugins/sigma.layout.forceAtlas2/supervisor.js"></script>
+<script src="../plugins/sigma.layout.forceLink/worker.js"></script>
+<script src="../plugins/sigma.layout.forceLink/supervisor.js"></script>
 
 <script src="../plugins/sigma.statistics.louvain/sigma.statistics.louvain.js"></script>
 <div id="container">
@@ -217,13 +217,14 @@ s = new sigma({
 });
 
 // Layout the graph to see node clusters:
-var fa = s.configForceAtlas2({
+var fa = sigma.layouts.configForceLink(s, {
   worker: true,
   autoStop: true,
   background: true,
   easing: 'cubicInOut'
 });
-s.startForceAtlas2();
+sigma.layouts.startForceLink();
+
 
 var louvainInstance;
 
@@ -247,11 +248,9 @@ document.getElementById('run-btn').addEventListener("click", function(e) {
 
   document.getElementById('nb-partitions').textContent = nbPartitions;
 
-  // Clear level selector first
-  document.getElementById('levels').innerHTML = '';
-
   // Fill level selector
   var levelElt = document.getElementById('levels');
+  levelElt.innerHTML = '';
   for (var i = 0; i < nbLevels; i++) {
     var optionElt = document.createElement("option");
     optionElt.text = i + 1;


### PR DESCRIPTION
The Louvain plugin example wasn't working for me. I would get the following error at line 220:

```javascript
Uncaught TypeError: Cannot read property 'configForceAtlas2' of undefined
```

The changes I made fixed it. If I'm missing something and it was supposed to work as is, please let me know.

I also made it so that the options in the Levels select get cleared before they are repopulated.

Cheers,
Julien