### PR TITLE
Custom renderer returns undefined

### DIFF
--- a/plugins/sigma.plugins.tooltips/sigma.plugins.tooltips.js
+++ b/plugins/sigma.plugins.tooltips/sigma.plugins.tooltips.js
@@ -156,8 +156,11 @@
           clone[k] = o[k];
 
         tooltipRenderer = options.renderer.call(s.graph, clone, options.template);
+		var type = typeof tooltipRenderer;
 
-        if (typeof tooltipRenderer === 'string')
+		if (type === 'undefined')
+			return;
+        if (type === 'string')
            _tooltip.innerHTML = tooltipRenderer;
         else
             // tooltipRenderer is a dom element:


### PR DESCRIPTION
When tooltips are initialised, the caller may define a custom renderer
for the tooltip template.  if said rendered returns undefined (it
declines to display a tooltip) the code will break with the error:
“NotFoundError: DOM Exception 8: An attempt was made to reference a
Node in a context where it does not exist.”

this patch fixes that by discontinuing processing when there is no
tooltip to render