### PR TITLE
Fix #194: add edgesLabels (+ a faster renderer via #168) and edgesShapes to linkurious renderer

### DIFF
--- a/plugins/sigma.renderers.linkurious/README.md
+++ b/plugins/sigma.renderers.linkurious/README.md
@@ -358,6 +358,9 @@ This plugin provides the following edge label renderers:
    * default value: `0`
    * available values: `0` (no shadow), `1` (low), `2`, `3`, `4`, `5` (high)
 
+
+### Edge labels settings
+
  * **defaultEdgeLabelColor**
    * type: *string*
    * default value: `#000`

--- a/plugins/sigma.renderers.linkurious/README.md
+++ b/plugins/sigma.renderers.linkurious/README.md
@@ -205,6 +205,41 @@ They may be used to reinforce a highligh effect on hover or selected nodes and e
 
 Levels are supported in Canvas only.
 
+
+## Edges shapes
+
+Registers custom edge shape renderers on **Canvas** only. See the following [example code](../../examples/plugin-customEdgeShapes.html) for full usage.
+
+### Shapes available
+
+The plugin implements the following shapes:
+  * `dashed`
+  * `dotted`
+  * `parallel`: two solid parallel lines representing an edge aggregating multiple edges in the original graph.
+  * `tapered` (see Danny Holten, Petra Isenberg, Jean-Daniel Fekete, and J. Van Wijk (2010) Performance Evaluation of Tapered, Curved, and Animated Directed-Edge Representations in Node-Link Graphs. Research Report, Sep 2010.)
+
+To assign a shape renderer to an edge, simply set `edge.type='shape-name'` e.g. `edge.type='dotted'`. The default renderer implemented by sigma.js is named `def` (alias `line`) - see also [generic custom edge renderer example](../../examples/custom-edge-renderer.html).
+
+![dashed](https://github.com/Linkurious/sigma.js/wiki/media/dashed1.png)
+![dotted](https://github.com/Linkurious/sigma.js/wiki/media/dotted1.png)
+![parallel](https://github.com/Linkurious/sigma.js/wiki/media/parallel1.png)
+![tapered](https://github.com/Linkurious/sigma.js/wiki/media/tapered1.png)
+
+## Edges labels
+
+Displays edge labels on **Canvas** only.
+
+See the following [example](../../examples/edge-renderers.html) for full usage.
+
+### Renderers
+
+This plugin provides the following edge label renderers:
+- `line` (default)
+- `arrow` (use default)
+- `curve`
+- `curvedArrow`
+
+
 ## Settings
 
  * **defaultLabelActiveColor**
@@ -323,6 +358,65 @@ Levels are supported in Canvas only.
    * default value: `0`
    * available values: `0` (no shadow), `1` (low), `2`, `3`, `4`, `5` (high)
 
+ * **defaultEdgeLabelColor**
+   * type: *string*
+   * default value: `#000`
+
+ * **defaultEdgeLabelActiveColor**
+   * type: *string*
+   * default value: `rgb(236, 81, 72)`
+
+ * **defaultEdgeLabelSize**
+   * type: *number*
+   * default value: `10`
+
+ * **edgeLabelSize**
+   * Indicates how to choose the edge labels size.
+   * type: *string*
+   * default value: `fixed`
+   * available values: `fixed`, `proportional`
+
+ * **edgeLabelAlignment**
+   * Indicates how to position the label relative to its edge.
+   * type: *string*
+   * default value: `auto`
+   * available values: `auto`, `horizontal`
+
+ * **edgeLabelSizePowRatio**
+   * The opposite power ratio between the font size of the label and the edge size.
+   * type: *number*
+   * default value: `0.8`
+
+````javascript
+// Formula:
+Math.pow(size, - 1 / edgeLabelSizePowRatio) * size * defaultEdgeLabelSize
+````
+
+ * **edgeLabelThreshold**
+   * The minimum size an edge must have to see its label displayed.
+   * type: *number*
+   * default value: `1`
+
+ * **defaultEdgeHoverLabelBGColor**
+   * type: *string*
+   * default value: `#fff`
+
+ * **edgeLabelHoverBGColor**
+   * Indicates how to choose the hovered edge labels color.
+   * type: *string*
+   * default value: `default`
+   * available values: `edge`, `default`
+
+ * **edgeLabelHoverShadow**
+   * Indicates how to choose the hovered edges shadow color.
+   * type: *string*
+   * default value: `default`
+   * available values: `edge`, `default`
+
+ * **edgeLabelHoverShadowColor**
+   * type: *string*
+   * default value: `#000`
+
 You may override the default values when instantiating Sigma, e.g.:
 
 ````javascript
@@ -334,6 +428,8 @@ var sigInst = new sigma({
   }
 });
 ````
+
+When included, the plugin change `drawEdgeLabels` default to `true`.
 
 #### Notes on spritesheets
 

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
@@ -1,0 +1,64 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edgehovers');
+
+  /**
+   * This hover renderer will display the edge with a different color or size.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edgehovers.dashed =
+    function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor');
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    if (settings('edgeHoverColor') === 'edge') {
+      color = edge.hover_color || color;
+    } else {
+      color = edge.hover_color || settings('defaultEdgeHoverColor') || color;
+    }
+    size *= settings('edgeHoverSizeRatio');
+
+    context.save();
+
+    context.setLineDash([8,3]);
+    context.strokeStyle = color;
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(
+      source[prefix + 'x'],
+      source[prefix + 'y']
+    );
+    context.lineTo(
+      target[prefix + 'x'],
+      target[prefix + 'y']
+    );
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
@@ -4,7 +4,8 @@
   sigma.utils.pkg('sigma.canvas.edgehovers');
 
   /**
-   * This hover renderer will display the edge with a different color or size.
+   * This hover renderer will display the edge with a different color or size..
+   * It will also display the label with a background.
    *
    * @param  {object}                   edge         The edge object.
    * @param  {object}                   source node  The edge source node.
@@ -21,7 +22,8 @@
         size = edge[prefix + 'size'] || 1,
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
-        defaultEdgeColor = settings('defaultEdgeColor');
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        level = settings('edgeHoverLevel');
 
     if (!color)
       switch (edgeColor) {
@@ -45,6 +47,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     context.setLineDash([8,3]);
     context.strokeStyle = color;
     context.lineWidth = size;
@@ -59,6 +94,20 @@
     );
     context.stroke();
 
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
+
     context.restore();
+
+    // draw label with a background
+    if (sigma.canvas.edges.labels) {
+      edge.hover = true;
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      edge.hover = false;
+    }
   };
 })();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dotted.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dotted.js
@@ -1,0 +1,64 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edgehovers');
+
+  /**
+   * This hover renderer will display the edge with a different color or size.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edgehovers.dotted =
+    function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor');
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    if (settings('edgeHoverColor') === 'edge') {
+      color = edge.hover_color || color;
+    } else {
+      color = edge.hover_color || settings('defaultEdgeHoverColor') || color;
+    }
+    size *= settings('edgeHoverSizeRatio');
+
+    context.save();
+
+    context.setLineDash([2]);
+    context.strokeStyle = color;
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(
+      source[prefix + 'x'],
+      source[prefix + 'y']
+    );
+    context.lineTo(
+      target[prefix + 'x'],
+      target[prefix + 'y']
+    );
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dotted.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dotted.js
@@ -4,7 +4,8 @@
   sigma.utils.pkg('sigma.canvas.edgehovers');
 
   /**
-   * This hover renderer will display the edge with a different color or size.
+   * This hover renderer will display the edge with a different color or size..
+   * It will also display the label with a background.
    *
    * @param  {object}                   edge         The edge object.
    * @param  {object}                   source node  The edge source node.
@@ -21,7 +22,8 @@
         size = edge[prefix + 'size'] || 1,
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
-        defaultEdgeColor = settings('defaultEdgeColor');
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        level = settings('edgeHoverLevel');
 
     if (!color)
       switch (edgeColor) {
@@ -45,6 +47,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     context.setLineDash([2]);
     context.strokeStyle = color;
     context.lineWidth = size;
@@ -59,6 +94,20 @@
     );
     context.stroke();
 
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
+
     context.restore();
+
+    // draw label with a background
+    if (sigma.canvas.edges.labels) {
+      edge.hover = true;
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      edge.hover = false;
+    }
   };
 })();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
@@ -1,0 +1,77 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edgehovers');
+
+  /**
+   * This hover renderer will display the edge with a different color or size.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edgehovers.parallel =
+    function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        sX = source[prefix + 'x'],
+        sY = source[prefix + 'y'],
+        tX = target[prefix + 'x'],
+        tY = target[prefix + 'y'],
+        c,
+        d,
+        dist = sigma.utils.getDistance(sX, sY, tX, tY);
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    if (settings('edgeHoverColor') === 'edge') {
+      color = edge.hover_color || color;
+    } else {
+      color = edge.hover_color || settings('defaultEdgeHoverColor') || color;
+    }
+    size *= settings('edgeHoverSizeRatio');
+
+    // Intersection points of the source node circle:
+    c = sigma.utils.getCircleIntersection(sX, sY, size, tX, tY, dist);
+
+    // Intersection points of the target node circle:
+    d = sigma.utils.getCircleIntersection(tX, tY, size, sX, sY, dist);
+
+    context.save();
+
+    context.strokeStyle = color;
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(c.xi, c.yi);
+    context.lineTo(d.xi_prime, d.yi_prime);
+    context.closePath();
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(c.xi_prime, c.yi_prime);
+    context.lineTo(d.xi, d.yi);
+    context.closePath();
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
@@ -4,7 +4,8 @@
   sigma.utils.pkg('sigma.canvas.edgehovers');
 
   /**
-   * This hover renderer will display the edge with a different color or size.
+   * This hover renderer will display the edge with a different color or size..
+   * It will also display the label with a background.
    *
    * @param  {object}                   edge         The edge object.
    * @param  {object}                   source node  The edge source node.
@@ -22,6 +23,7 @@
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
         defaultEdgeColor = settings('defaultEdgeColor'),
+        level = settings('edgeHoverLevel'),
         sX = source[prefix + 'x'],
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
@@ -58,6 +60,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     context.strokeStyle = color;
     context.lineWidth = size;
     context.beginPath();
@@ -72,6 +107,20 @@
     context.closePath();
     context.stroke();
 
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
+
     context.restore();
+
+    // draw label with a background
+    if (sigma.canvas.edges.labels) {
+      edge.hover = true;
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      edge.hover = false;
+    }
   };
 })();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
@@ -1,0 +1,74 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edgehovers');
+
+  /**
+   * This hover renderer will display the edge with a different color or size.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edgehovers.tapered =
+    function(edge, source, target, context, settings) {
+    // The goal is to draw a triangle where the target node is a point of
+    // the triangle, and the two other points are the intersection of the
+    // source circle and the circle (target, distance(source, target)).
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        prefix = settings('prefix') || '',
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        sX = source[prefix + 'x'],
+        sY = source[prefix + 'y'],
+        tX = target[prefix + 'x'],
+        tY = target[prefix + 'y'],
+        dist = sigma.utils.getDistance(sX, sY, tX, tY);
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    if (settings('edgeHoverColor') === 'edge') {
+      color = edge.hover_color || color;
+    } else {
+      color = edge.hover_color || settings('defaultEdgeHoverColor') || color;
+    }
+    size *= settings('edgeHoverSizeRatio');
+
+    // Intersection points:
+    var c = sigma.utils.getCircleIntersection(sX, sY, size, tX, tY, dist);
+
+    context.save();
+
+    // Turn transparency on:
+    context.globalAlpha = 0.65;
+
+    // Draw the triangle:
+    context.fillStyle = color;
+    context.beginPath();
+    context.moveTo(tX, tY);
+    context.lineTo(c.xi, c.yi);
+    context.lineTo(c.xi_prime, c.yi_prime);
+    context.closePath();
+    context.fill();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
@@ -5,6 +5,7 @@
 
   /**
    * This hover renderer will display the edge with a different color or size.
+   * It will also display the label with a background.
    *
    * @param  {object}                   edge         The edge object.
    * @param  {object}                   source node  The edge source node.
@@ -14,7 +15,7 @@
    */
   sigma.canvas.edgehovers.tapered =
     function(edge, source, target, context, settings) {
-    // The goal is to draw a triangle where the target node is a point of
+    // The goal is to draw a triangle where the target node is a point of 
     // the triangle, and the two other points are the intersection of the
     // source circle and the circle (target, distance(source, target)).
     var color = edge.active ?
@@ -26,6 +27,7 @@
         prefix = settings('prefix') || '',
         defaultNodeColor = settings('defaultNodeColor'),
         defaultEdgeColor = settings('defaultEdgeColor'),
+        level = settings('edgeHoverLevel'),
         sX = source[prefix + 'x'],
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
@@ -57,6 +59,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     // Turn transparency on:
     context.globalAlpha = 0.65;
 
@@ -69,6 +104,20 @@
     context.closePath();
     context.fill();
 
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
+
     context.restore();
+
+    // draw label with a background
+    if (sigma.canvas.edges.labels) {
+      edge.hover = true;
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      edge.hover = false;
+    }
   };
 })();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dashed.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dashed.js
@@ -1,0 +1,64 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edges');
+
+  /**
+   * This method renders the edge as a dashed line.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.dashed = function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor');
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    context.save();
+
+    if (edge.active) {
+      context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
+        (color || defaultEdgeColor) :
+        settings('defaultEdgeActiveColor');
+    }
+    else {
+      context.strokeStyle = color;
+    }
+
+    context.setLineDash([8,3]);
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(
+      source[prefix + 'x'],
+      source[prefix + 'y']
+    );
+    context.lineTo(
+      target[prefix + 'x'],
+      target[prefix + 'y']
+    );
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dashed.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dashed.js
@@ -20,7 +20,8 @@
         size = edge[prefix + 'size'] || 1,
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
-        defaultEdgeColor = settings('defaultEdgeColor');
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        level = edge.active ? settings('edgeActiveLevel') : edge.level;
 
     if (!color)
       switch (edgeColor) {
@@ -36,6 +37,39 @@
       }
 
     context.save();
+
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
 
     if (edge.active) {
       context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
@@ -58,6 +92,13 @@
       target[prefix + 'y']
     );
     context.stroke();
+
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
 
     context.restore();
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dotted.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dotted.js
@@ -1,0 +1,64 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edges');
+
+  /**
+   * This method renders the edge as a dotted line.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.dotted = function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor');
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    context.save();
+
+    if (edge.active) {
+      context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
+        (color || defaultEdgeColor) :
+        settings('defaultEdgeActiveColor');
+    }
+    else {
+      context.strokeStyle = color;
+    }
+
+    context.setLineDash([2]);
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(
+      source[prefix + 'x'],
+      source[prefix + 'y']
+    );
+    context.lineTo(
+      target[prefix + 'x'],
+      target[prefix + 'y']
+    );
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dotted.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.dotted.js
@@ -20,7 +20,8 @@
         size = edge[prefix + 'size'] || 1,
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
-        defaultEdgeColor = settings('defaultEdgeColor');
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        level = edge.active ? settings('edgeActiveLevel') : edge.level;
 
     if (!color)
       switch (edgeColor) {
@@ -36,6 +37,39 @@
       }
 
     context.save();
+
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
 
     if (edge.active) {
       context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
@@ -58,6 +92,13 @@
       target[prefix + 'y']
     );
     context.stroke();
+
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
 
     context.restore();
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curve.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curve.js
@@ -54,11 +54,9 @@
       c = sigma.utils.getPointOnBezierCurve(
         t, sX, sY, tX, tY, cp.x1, cp.y1, cp.x2, cp.y2
       );
-      angle = Math.atan2(1, 1); // 45°
     } else {
       cp = sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY);
       c = sigma.utils.getPointOnQuadraticCurve(t, sX, sY, tX, tY, cp.x, cp.y);
-      angle = Math.atan2(dY * sign, dX * sign);
     }
 
     // The font size is sublineraly proportional to the edge size, in order to

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curve.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curve.js
@@ -1,0 +1,183 @@
+;(function(undefined) {
+  'use strict';
+
+  if (typeof sigma === 'undefined')
+    throw 'sigma is not declared';
+
+  // Initialize packages:
+  sigma.utils.pkg('sigma.canvas.edges.labels');
+
+  /**
+   * This label renderer will just display the label on the curve of the edge.
+   * The label is rendered at half distance of the edge extremities, and is
+   * always oriented from left to right on the top side of the curve.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.labels.curve =
+    function(edge, source, target, context, settings) {
+    if (typeof edge.label !== 'string')
+      return;
+
+    var prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1;
+
+    if (size < settings('edgeLabelThreshold') && !edge.hover)
+      return;
+
+    if (0 === settings('edgeLabelSizePowRatio'))
+      throw new Error('Invalid setting: "edgeLabelSizePowRatio" is equal to 0.');
+
+    var fontSize,
+        sSize = source[prefix + 'size'],
+        sX = source[prefix + 'x'],
+        sY = source[prefix + 'y'],
+        tX = target[prefix + 'x'],
+        tY = target[prefix + 'y'],
+        dX = tX - sX,
+        dY = tY - sY,
+        sign = (sX < tX) ? 1 : -1,
+        cp = {},
+        c,
+        angle = 0,
+        t = 0.5,  //length of the curve
+        fontStyle = edge.hover ?
+          (settings('hoverFontStyle') || settings('fontStyle')) :
+          settings('fontStyle');
+
+    if (source.id === target.id) {
+      cp = sigma.utils.getSelfLoopControlPoints(sX, sY, sSize);
+      c = sigma.utils.getPointOnBezierCurve(
+        t, sX, sY, tX, tY, cp.x1, cp.y1, cp.x2, cp.y2
+      );
+      angle = Math.atan2(1, 1); // 45°
+    } else {
+      cp = sigma.utils.getQuadraticControlPoint(sX, sY, tX, tY);
+      c = sigma.utils.getPointOnQuadraticCurve(t, sX, sY, tX, tY, cp.x, cp.y);
+      angle = Math.atan2(dY * sign, dX * sign);
+    }
+
+    // The font size is sublineraly proportional to the edge size, in order to
+    // avoid very large labels on screen.
+    // This is achieved by f(x) = x * x^(-1/ a), where 'x' is the size and 'a'
+    // is the edgeLabelSizePowRatio. Notice that f(1) = 1.
+    // The final form is:
+    // f'(x) = b * x * x^(-1 / a), thus f'(1) = b. Application:
+    // fontSize = defaultEdgeLabelSize if edgeLabelSizePowRatio = 1
+    fontSize = (settings('edgeLabelSize') === 'fixed') ?
+      settings('defaultEdgeLabelSize') :
+      settings('defaultEdgeLabelSize') *
+      size *
+      Math.pow(size, -1 / settings('edgeLabelSizePowRatio'));
+
+    context.save();
+
+    if (edge.active) {
+      context.font = [
+        settings('activeFontStyle') || settings('fontStyle'),
+        fontSize + 'px',
+        settings('activeFont') || settings('font')
+      ].join(' ');
+    }
+    else {
+      context.font = [
+        fontStyle,
+        fontSize + 'px',
+        settings('font')
+      ].join(' ');
+    }
+
+    context.textAlign = 'center';
+    context.textBaseline = 'alphabetic';
+
+    // force horizontal alignment if not enough space to draw the text,
+    // otherwise draw text along the edge curve:
+    if ('auto' === settings('edgeLabelAlignment')) {
+      if (source.id === target.id) {
+        angle = Math.atan2(1, 1); // 45°
+      } else {
+        var
+          labelWidth = context.measureText(edge.label).width,
+          edgeLength = sigma.utils.getDistance(
+            source[prefix + 'x'],
+            source[prefix + 'y'],
+            target[prefix + 'x'],
+            target[prefix + 'y']);
+
+          // reduce node sizes + constant
+          edgeLength = edgeLength - source[prefix + 'size'] - target[prefix + 'size'] - 10;
+
+        if (labelWidth < edgeLength) {
+          angle = Math.atan2(dY * sign, dX * sign);
+        }
+      }
+    }
+
+    if (edge.hover) {
+      // Label background:
+      context.fillStyle = settings('edgeLabelHoverBGColor') === 'edge' ?
+        (edge.color || settings('defaultEdgeColor')) :
+        settings('defaultEdgeHoverLabelBGColor');
+
+      if (settings('edgeLabelHoverShadow')) {
+        context.shadowOffsetX = 0;
+        context.shadowOffsetY = 0;
+        context.shadowBlur = 8;
+        context.shadowColor = settings('edgeLabelHoverShadowColor');
+      }
+
+      drawBackground(angle, context, fontSize, size, edge.label, c.x, c.y);
+
+      if (settings('edgeLabelHoverShadow')) {
+        context.shadowBlur = 0;
+        context.shadowColor = '#000';
+      }
+    }
+
+    if (edge.active) {
+      context.fillStyle =
+        settings('edgeActiveColor') === 'edge' ?
+        (edge.active_color || settings('defaultEdgeActiveColor')) :
+        settings('defaultEdgeLabelActiveColor');
+    }
+    else {
+      context.fillStyle =
+        (settings('edgeLabelColor') === 'edge') ?
+        (edge.color || settings('defaultEdgeColor')) :
+        settings('defaultEdgeLabelColor');
+    }
+
+    context.translate(c.x, c.y);
+    context.rotate(angle);
+    context.fillText(
+      edge.label,
+      0,
+      (-size / 2) - 3
+    );
+
+    context.restore();
+
+    function drawBackground(angle, context, fontSize, size, label, x, y) {
+      var w = Math.round(
+            context.measureText(label).width + size + 1.5 + fontSize / 3
+          ),
+          h = fontSize + 4;
+
+      context.save();
+      context.beginPath();
+
+      // draw a rectangle for the label
+      context.translate(x, y);
+      context.rotate(angle);
+      context.rect(-w / 2, -h -size/2, w, h);
+
+      context.closePath();
+      context.fill();
+      context.restore();
+    }
+  };
+}).call(this);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curvedArrow.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.curvedArrow.js
@@ -1,0 +1,25 @@
+;(function(undefined) {
+  'use strict';
+
+  if (typeof sigma === 'undefined')
+    throw 'sigma is not declared';
+
+  // Initialize packages:
+  sigma.utils.pkg('sigma.canvas.edges.labels');
+
+  /**
+   * This label renderer will just display the label on the curve of the edge.
+   * The label is rendered at half distance of the edge extremities, and is
+   * always oriented from left to right on the top side of the curve.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.labels.curvedArrow =
+    function(edge, source, target, context, settings) {
+    sigma.canvas.edges.labels.curve(edge, source, target, context, settings);
+  };
+}).call(this);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.labels.def.js
@@ -1,0 +1,186 @@
+;(function(undefined) {
+  'use strict';
+
+  if (typeof sigma === 'undefined')
+    throw 'sigma is not declared';
+
+  // Initialize packages:
+  sigma.utils.pkg('sigma.canvas.edges.labels');
+
+  var PREV_FONT = null; //contains the current context.font value
+
+  sigma.canvas.edges.labels.def = {
+    pre: function(context, settings) {
+      PREV_FONT = '';
+    },
+  };
+  
+  /**
+   * This label renderer will just display the label on the line of the edge.
+   * The label is rendered at half distance of the edge extremities, and is
+   * always oriented from left to right on the top side of the line.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.labels.def.render =
+    function(edge, source, target, context, settings) {
+    if (typeof edge.label !== 'string' || source == target)
+      return;
+
+    var prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1;
+
+    if (size < settings('edgeLabelThreshold') && !edge.hover)
+      return;
+
+    if (0 === settings('edgeLabelSizePowRatio'))
+      throw new Error('Invalid setting: "edgeLabelSizePowRatio" is equal to 0.');
+
+    var fontSize,
+        angle = 0,
+        fontStyle = edge.hover ?
+          (settings('hoverFontStyle') || settings('fontStyle')) :
+          settings('fontStyle'),
+        x = (source[prefix + 'x'] + target[prefix + 'x']) / 2,
+        y = (source[prefix + 'y'] + target[prefix + 'y']) / 2,
+        dX, dY, sign;
+
+    // The font size is sublineraly proportional to the edge size, in order to
+    // avoid very large labels on screen.
+    // This is achieved by f(x) = x * x^(-1/ a), where 'x' is the size and 'a'
+    // is the edgeLabelSizePowRatio. Notice that f(1) = 1.
+    // The final form is:
+    // f'(x) = b * x * x^(-1 / a), thus f'(1) = b. Application:
+    // fontSize = defaultEdgeLabelSize if edgeLabelSizePowRatio = 1
+
+    fontSize = (settings('edgeLabelSize') === 'fixed') ?
+      settings('defaultEdgeLabelSize') :
+      settings('defaultEdgeLabelSize') *
+      size *
+      Math.pow(size, -1 / settings('edgeLabelSizePowRatio'));
+
+    var new_font = [
+        fontStyle,
+        fontSize + 'px',
+        settings('font')
+      ].join(' ');
+    if (edge.active) {
+     new_font = [
+        settings('activeFontStyle') || settings('fontStyle'),
+        fontSize + 'px',
+        settings('activeFont') || settings('font')
+      ].join(' ');
+    }
+
+    //fallback if the font value caching is not available
+    if (PREV_FONT === null) {
+      context.font = new_font;
+    } else if (PREV_FONT != new_font) { //use font value caching
+      context.font = new_font;
+      PREV_FONT = new_font;
+    }
+
+    context.textAlign = 'center';
+    context.textBaseline = 'alphabetic';
+
+    // force horizontal alignment if not enough space to draw the text,
+    // otherwise draw text along the edge line:
+    if ('auto' === settings('edgeLabelAlignment')) {
+      var labelWidth;
+      if (settings('approximateLabelWidth')) {
+        labelWidth = 0.5 * edge.label.length * fontSize;
+      }else {
+        labelWidth = context.measureText(edge.label).width;
+      }
+      var edgeLength = sigma.utils.getDistance(
+          source[prefix + 'x'],
+          source[prefix + 'y'],
+          target[prefix + 'x'],
+          target[prefix + 'y']);
+
+        // reduce node sizes + constant
+        edgeLength = edgeLength - source[prefix + 'size'] - target[prefix + 'size'] - 10;
+
+      if (labelWidth < edgeLength) {
+        dX = target[prefix + 'x'] - source[prefix + 'x'];
+        dY = target[prefix + 'y'] - source[prefix + 'y'];
+        sign = (source[prefix + 'x'] < target[prefix + 'x']) ? 1 : -1;
+        angle = Math.atan2(dY * sign, dX * sign);
+      }
+    }
+
+    if (edge.hover) {
+      // Label background:
+      context.fillStyle = settings('edgeLabelHoverBGColor') === 'edge' ?
+        (edge.color || settings('defaultEdgeColor')) :
+        settings('defaultEdgeHoverLabelBGColor');
+
+      if (settings('edgeLabelHoverShadow')) {
+        context.shadowOffsetX = 0;
+        context.shadowOffsetY = 0;
+        context.shadowBlur = 8;
+        context.shadowColor = settings('edgeLabelHoverShadowColor');
+      }
+
+      drawBackground(angle, context, fontSize, size, edge.label, x, y);
+
+      if (settings('edgeLabelHoverShadow')) {
+        context.shadowBlur = 0;
+        context.shadowColor = '#000';
+      }
+    }
+
+    if (edge.active) {
+      context.fillStyle =
+        settings('edgeActiveColor') === 'edge' ?
+        (edge.active_color || settings('defaultEdgeActiveColor')) :
+        settings('defaultEdgeLabelActiveColor');
+    }
+    else {
+      context.fillStyle =
+        (settings('edgeLabelColor') === 'edge') ?
+        (edge.color || settings('defaultEdgeColor')) :
+        settings('defaultEdgeLabelColor');
+    }
+
+    context.translate(x, y);
+    context.rotate(angle);
+    context.fillText(
+      edge.label,
+      0,
+      (-size / 2) - 3
+    );
+    context.rotate(-angle);
+    context.translate(-x, -y);
+  };
+
+
+  function drawBackground(angle, context, fontSize, size, label, x, y) {
+    var w = Math.round(
+          context.measureText(label).width + size + 1.5 + fontSize / 3
+        ),
+        h = fontSize + 4;
+
+    context.save();
+    context.beginPath();
+
+    // draw a rectangle for the label
+    context.translate(x, y);
+    context.rotate(angle);
+    context.rect(-w / 2, -h - size / 2, w, h);
+
+    context.closePath();
+    context.fill();
+    context.restore();
+  }
+
+  //fallback if the new rendering system is not available
+  if (sigma.renderers.canvas.applyRenderers === undefined) {
+    sigma.canvas.edges.labels.def = sigma.canvas.edges.labels.def.render;
+  }
+
+}).call(this);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.parallel.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.parallel.js
@@ -1,0 +1,77 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edges');
+
+  /**
+   * This method renders the edge as two parallel lines.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.parallel = function(edge, source, target, context, settings) {
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        sX = source[prefix + 'x'],
+        sY = source[prefix + 'y'],
+        tX = target[prefix + 'x'],
+        tY = target[prefix + 'y'],
+        c,
+        d,
+        dist = sigma.utils.getDistance(sX, sY, tX, tY);
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    // Intersection points of the source node circle:
+    c = sigma.utils.getCircleIntersection(sX, sY, size, tX, tY, dist);
+
+    // Intersection points of the target node circle:
+    d = sigma.utils.getCircleIntersection(tX, tY, size, sX, sY, dist);
+
+    context.save();
+
+    if (edge.active) {
+      context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
+        (color || defaultEdgeColor) :
+        settings('defaultEdgeActiveColor');
+    }
+    else {
+      context.strokeStyle = color;
+    }
+
+    context.lineWidth = size;
+    context.beginPath();
+    context.moveTo(c.xi, c.yi);
+    context.lineTo(d.xi_prime, d.yi_prime);
+    context.closePath();
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(c.xi_prime, c.yi_prime);
+    context.lineTo(d.xi, d.yi);
+    context.closePath();
+    context.stroke();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.parallel.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.parallel.js
@@ -21,6 +21,7 @@
         edgeColor = settings('edgeColor'),
         defaultNodeColor = settings('defaultNodeColor'),
         defaultEdgeColor = settings('defaultEdgeColor'),
+        level = edge.active ? settings('edgeActiveLevel') : edge.level,
         sX = source[prefix + 'x'],
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
@@ -50,6 +51,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     if (edge.active) {
       context.strokeStyle = settings('edgeActiveColor') === 'edge' ?
         (color || defaultEdgeColor) :
@@ -71,6 +105,13 @@
     context.lineTo(d.xi, d.yi);
     context.closePath();
     context.stroke();
+
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
 
     context.restore();
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.tapered.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.tapered.js
@@ -1,0 +1,77 @@
+;(function() {
+  'use strict';
+
+  sigma.utils.pkg('sigma.canvas.edges');
+
+  /**
+   * This method renders the edge as a tapered line.
+   * Danny Holten, Petra Isenberg, Jean-Daniel Fekete, and J. Van Wijk (2010)
+   * Performance Evaluation of Tapered, Curved, and Animated Directed-Edge
+   * Representations in Node-Link Graphs. Research Report, Sep 2010.
+   *
+   * @param  {object}                   edge         The edge object.
+   * @param  {object}                   source node  The edge source node.
+   * @param  {object}                   target node  The edge target node.
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+  sigma.canvas.edges.tapered = function(edge, source, target, context, settings) {
+    // The goal is to draw a triangle where the target node is a point of
+    // the triangle, and the two other points are the intersection of the
+    // source circle and the circle (target, distance(source, target)).
+    var color = edge.active ?
+          edge.active_color || settings('defaultEdgeActiveColor') :
+          edge.color,
+        prefix = settings('prefix') || '',
+        size = edge[prefix + 'size'] || 1,
+        edgeColor = settings('edgeColor'),
+        prefix = settings('prefix') || '',
+        defaultNodeColor = settings('defaultNodeColor'),
+        defaultEdgeColor = settings('defaultEdgeColor'),
+        sX = source[prefix + 'x'],
+        sY = source[prefix + 'y'],
+        tX = target[prefix + 'x'],
+        tY = target[prefix + 'y'],
+        dist = sigma.utils.getDistance(sX, sY, tX, tY);
+
+    if (!color)
+      switch (edgeColor) {
+        case 'source':
+          color = source.color || defaultNodeColor;
+          break;
+        case 'target':
+          color = target.color || defaultNodeColor;
+          break;
+        default:
+          color = defaultEdgeColor;
+          break;
+      }
+
+    // Intersection points:
+    var c = sigma.utils.getCircleIntersection(sX, sY, size, tX, tY, dist);
+
+    context.save();
+
+    if (edge.active) {
+      context.fillStyle = settings('edgeActiveColor') === 'edge' ?
+        (color || defaultEdgeColor) :
+        settings('defaultEdgeActiveColor');
+    }
+    else {
+      context.fillStyle = color;
+    }
+
+    // Turn transparency on:
+    context.globalAlpha = 0.65;
+
+    // Draw the triangle:
+    context.beginPath();
+    context.moveTo(tX, tY);
+    context.lineTo(c.xi, c.yi);
+    context.lineTo(c.xi_prime, c.yi_prime);
+    context.closePath();
+    context.fill();
+
+    context.restore();
+  };
+})();

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.tapered.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edges.tapered.js
@@ -16,7 +16,7 @@
    * @param  {configurable}             settings     The settings function.
    */
   sigma.canvas.edges.tapered = function(edge, source, target, context, settings) {
-    // The goal is to draw a triangle where the target node is a point of
+    // The goal is to draw a triangle where the target node is a point of 
     // the triangle, and the two other points are the intersection of the
     // source circle and the circle (target, distance(source, target)).
     var color = edge.active ?
@@ -28,6 +28,7 @@
         prefix = settings('prefix') || '',
         defaultNodeColor = settings('defaultNodeColor'),
         defaultEdgeColor = settings('defaultEdgeColor'),
+        level = edge.active ? settings('edgeActiveLevel') : edge.level,
         sX = source[prefix + 'x'],
         sY = source[prefix + 'y'],
         tX = target[prefix + 'x'],
@@ -52,6 +53,39 @@
 
     context.save();
 
+    // Level:
+    if (level) {
+      context.shadowOffsetX = 0;
+      // inspired by Material Design shadows, level from 1 to 5:
+      switch(level) {
+        case 1:
+          context.shadowOffsetY = 1.5;
+          context.shadowBlur = 4;
+          context.shadowColor = 'rgba(0,0,0,0.36)';
+          break;
+        case 2:
+          context.shadowOffsetY = 3;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.39)';
+          break;
+        case 3:
+          context.shadowOffsetY = 6;
+          context.shadowBlur = 12;
+          context.shadowColor = 'rgba(0,0,0,0.42)';
+          break;
+        case 4:
+          context.shadowOffsetY = 10;
+          context.shadowBlur = 20;
+          context.shadowColor = 'rgba(0,0,0,0.47)';
+          break;
+        case 5:
+          context.shadowOffsetY = 15;
+          context.shadowBlur = 24;
+          context.shadowColor = 'rgba(0,0,0,0.52)';
+          break;
+      }
+    }
+
     if (edge.active) {
       context.fillStyle = settings('edgeActiveColor') === 'edge' ?
         (color || defaultEdgeColor) :
@@ -71,6 +105,13 @@
     context.lineTo(c.xi_prime, c.yi_prime);
     context.closePath();
     context.fill();
+
+    // reset shadow
+    if (level) {
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
+      context.shadowColor = '#000000'
+    }
 
     context.restore();
   };

--- a/plugins/sigma.renderers.linkurious/settings.js
+++ b/plugins/sigma.renderers.linkurious/settings.js
@@ -95,6 +95,9 @@
     // {string} Indicates how to choose the edge labels size. Available values:
     //          "fixed", "proportional"
     edgeLabelSize: 'fixed',
+    // {string} Label position relative to its edge. Available values:
+    //          "auto", "horizontal"
+    edgeLabelAlignment: 'auto',
     // {string} The opposite power ratio between the font size of the label and
     // the edge size:
     // Math.pow(size, -1 / edgeLabelSizePowRatio) * size * defaultEdgeLabelSize

--- a/plugins/sigma.renderers.linkurious/settings.js
+++ b/plugins/sigma.renderers.linkurious/settings.js
@@ -80,10 +80,41 @@
     imageThreshold: 8,
     // {string} Controls the security policy of the image loading, from the
     // browser's side.
-    imgCrossOrigin: 'anonymous'
+    imgCrossOrigin: 'anonymous',
+
+    /**
+     * EDGE LABELS
+     * *******************
+     */
+    // {string}
+    defaultEdgeLabelColor: '#000',
+    // {string}
+    defaultEdgeLabelActiveColor: '#000',
+    // {string}
+    defaultEdgeLabelSize: 10,
+    // {string} Indicates how to choose the edge labels size. Available values:
+    //          "fixed", "proportional"
+    edgeLabelSize: 'fixed',
+    // {string} The opposite power ratio between the font size of the label and
+    // the edge size:
+    // Math.pow(size, -1 / edgeLabelSizePowRatio) * size * defaultEdgeLabelSize
+    edgeLabelSizePowRatio: 1,
+    // {number} The minimum size an edge must have to see its label displayed.
+    edgeLabelThreshold: 1,
+    // {string}
+    defaultEdgeHoverLabelBGColor: '#fff',
+    // {string} Indicates how to choose the hovered edge labels color.
+    //          Available values: "edge", "default"
+    edgeLabelHoverBGColor: 'default',
+    // {string} Indicates how to choose the hovered edges shadow color.
+    //          Available values: "edge", "default"
+    edgeLabelHoverShadow: 'default',
+    // {string}
+    edgeLabelHoverShadowColor: '#000'
   };
 
   // Export the previously designed settings:
   sigma.settings = sigma.utils.extend(sigma.settings || {}, settings);
+  sigma.settings.drawEdgeLabels = true;
 
 }).call(this);


### PR DESCRIPTION
Need to review `sigma.canvas.edges.labels.def.js` which include a render fallback `ctx.font` caching 