### PR TITLE
Improve node labels renderers

### DIFF
--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -112,9 +112,10 @@
         (node.color || defaultNodeColor) :
         settings('defaultLabelHoverColor');
 
-      var labelWidth = getTextWidth(node.label),
-          labelOffsetX = - labelWidth * 0.5,
-          labelOffsetY = fontSize / 3;
+      var labelOffsetX = 0,
+          labelOffsetY = fontSize / 3,
+          labelWidth;
+      context.textAlign = "center";
 
       switch (alignment) {
         case 'bottom':
@@ -123,12 +124,14 @@
         case 'center':
           break;
         case 'left':
+          context.textAlign = "right";
           labelOffsetX = - size - borderSize - settings('outerBorderSize') - 3 - labelWidth;
           break;
         case 'top':
           labelOffsetY = - size - 2 * fontSize / 3;
           break;
         case 'inside':
+          labelWidth = getTextWidth(node.label);
           if (labelWidth <= (size + fontSize / 3) * 2) {
             break;
           }
@@ -137,6 +140,7 @@
         /* falls through*/
         default:
           labelOffsetX = size + borderSize + settings('outerBorderSize') + 3;
+          context.textAlign = "left";
           break;
       }
 
@@ -149,7 +153,7 @@
 
     function getTextWidth(text) {
       return settings('approximateLabelWidth') ?
-        0.5 * text.length * fontSize :
+        0.6 * text.length * fontSize :
         context.measureText(text).width;
     }
 

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
@@ -24,7 +24,7 @@
   };
 
   /**
-   * This label renderer will just display the label on the right of the node.
+   * This label renderer will display the label of the node
    *
    * @param  {object}                   node     The node object.
    * @param  {CanvasRenderingContext2D} context  The canvas context.
@@ -47,7 +47,7 @@
     if (size < settings('labelThreshold'))
       return;
 
-    if (typeof node.label !== 'string')
+    if (!node.label || typeof node.label !== 'string')
       return;
 
     fontSize = (settings('labelSize') === 'fixed') ?

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
@@ -7,6 +7,22 @@
   // Initialize packages:
   sigma.utils.pkg('sigma.canvas.labels');
 
+  var PREV_FONT = null; //contains the current context.font value
+  //the ctx.font value is cached because accesing it is costly
+
+  sigma.canvas.labels.def = {
+  /**
+   * This is executed before a render batch
+   * It just reset PREV_FONT
+   *
+   * @param  {CanvasRenderingContext2D} context      The canvas context.
+   * @param  {configurable}             settings     The settings function.
+   */
+    pre: function(context, settings) {
+      PREV_FONT = '';
+    },
+  };
+
   /**
    * This label renderer will just display the label on the right of the node.
    *
@@ -14,7 +30,8 @@
    * @param  {CanvasRenderingContext2D} context  The canvas context.
    * @param  {configurable}             settings The settings function.
    */
-  sigma.canvas.labels.def = function(node, context, settings) {
+  sigma.canvas.labels.def.render = 
+        function(node, context, settings) {
     var fontSize,
         prefix = settings('prefix') || '',
         size = node[prefix + 'size'] || 1,
@@ -37,11 +54,16 @@
       settings('defaultLabelSize') :
       settings('labelSizeRatio') * size;
 
-    context.font = (fontStyle ? fontStyle + ' ' : '') +
+    var new_font = (fontStyle ? fontStyle + ' ' : '') +
       fontSize + 'px ' +
       (node.active ?
         settings('activeFont') || settings('font') :
         settings('font'));
+
+    if (PREV_FONT != new_font) { //use font value caching
+      context.font = new_font;
+      PREV_FONT = new_font;
+    }
 
     if (node.active)
       context.fillStyle =
@@ -54,13 +76,9 @@
         node.color || settings('defaultNodeColor') :
         settings('defaultLabelColor');
 
-    if (settings('approximateLabelWidth')) {
-      labelWidth = 0.5 * node.label.length * fontSize;
-    } else {
-      labelWidth = context.measureText(node.label).width;
-    }
-    labelOffsetX = - labelWidth / 2;
+    labelOffsetX = 0;
     labelOffsetY = fontSize / 3;
+    context.textAlign = "center";
 
     switch (alignment) {
       case 'bottom':
@@ -69,12 +87,18 @@
       case 'center':
         break;
       case 'left':
-        labelOffsetX = - size - borderSize - 3 - labelWidth;
+        context.textAlign = "right";
+        labelOffsetX = - size - borderSize - 3 ;
         break;
       case 'top':
         labelOffsetY = - size - 2 * fontSize / 3;
         break;
       case 'inside':
+        if (settings('approximateLabelWidth')) {
+          labelWidth = 0.5 * node.label.length * fontSize;
+        } else {
+          labelWidth = context.measureText(node.label).width;
+        }
         if (labelWidth <= (size + fontSize / 3) * 2) {
           break;
         }
@@ -83,6 +107,7 @@
       /* falls through*/
       default:
         labelOffsetX = size + borderSize + 3;
+        context.textAlign = "left";
         break;
     }
 


### PR DESCRIPTION
![bench](http://i.imgur.com/Z9lBL0T.png)

* Improve correctness of node hover (we don't want the background to be smaller than the label)
* Make the label rendering ~70% faster (with the `min` metric which is a good stable indicator)