### PR TITLE
Port plugins to pre/post system

### DIFF
--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dashed.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dashed.js
@@ -106,7 +106,8 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      var def = sigma.canvas.edges.labels.def;
+      (def.render || def)(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dotted.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dotted.js
@@ -106,7 +106,8 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      var def = sigma.canvas.edges.labels.def;
+      (def.render || def)(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.parallel.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.parallel.js
@@ -119,7 +119,8 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      var def = sigma.canvas.edges.labels.def;
+      (def.render || def)(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.tapered.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.tapered.js
@@ -116,7 +116,8 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
+      var def = sigma.canvas.edges.labels.def;
+      (def.render || def)(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.extremities.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.extremities.def.js
@@ -20,19 +20,19 @@
   sigma.canvas.extremities.def =
     function(edge, source, target, context, settings) {
     // Source Node:
-    (
+    var def = (
       sigma.canvas.hovers[source.type] ||
       sigma.canvas.hovers.def
-    ) (
-      source, context, settings
     );
+    def = def.render || def;
+    def(source, context, settings);
 
     // Target Node:
-    (
+    def = (
       sigma.canvas.hovers[target.type] ||
       sigma.canvas.hovers.def
-    ) (
-      target, context, settings
     );
+    def = def.render || def;
+    def(target, context, settings);
   };
 }).call(this);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -93,6 +93,7 @@
 
     // Node:
     var nodeRenderer = sigma.canvas.nodes[node.type] || sigma.canvas.nodes.def;
+    nodeRenderer = nodeRenderer.render || nodeRenderer;
     nodeRenderer(node, context, settings, { color: color });
 
     // reset shadow


### PR DESCRIPTION
#169

Issue with the current solution: pre() and post() are not called for now when renderers are using other renderers.

Some ideas for the solution:

* Port every renderer to the new pre/post system (time-consuming and compatibility-breaking but easier to reason with)
* Call pre()/render()/post() via a applyRenderer function (or only def() if it's an old and simple renderer)
* Have the new renderers handle the case where they are only called by render() (like now)

A cool idea:

**Instead of a pre/render/post system, have a def that can take a generator, an array or a single item**

* Solve interaction between renderers
* Not gonna use lot of memory since it's a generator