### PR TITLE
Simple fix for #213: disable double onMove render during panning

### DIFF
--- a/src/misc/sigma.misc.bindEvents.js
+++ b/src/misc/sigma.misc.bindEvents.js
@@ -500,7 +500,6 @@
       captor.bind('mouseout', onOut);
       captor.bind('doubleclick', onDoubleClick);
       captor.bind('rightclick', onRightClick);
-      self.bind('render', onMove);
     }
 
     for (i = 0, l = this.captors.length; i < l; i++)


### PR DESCRIPTION
Simple solution to #213: Disable the bug introduced by https://github.com/Linkurious/linkurious.js/commit/fca91dcc1aed9a3741d2cacad60c6f4f1a126fd2 by disabling the continuons rendering of the hovered node