### PR TITLE
Border support for default node renderer

### DIFF
--- a/plugins/sigma.parsers.cypher/sigma.parsers.cypher.js
+++ b/plugins/sigma.parsers.cypher/sigma.parsers.cypher.js
@@ -68,7 +68,7 @@
             edgesMap = {},
             key;
 
-		if (typeof result === 'object') result = result.results[0].data;
+        if (typeof result === 'object') result = result.results[0].data;
         // Iteration on all result data
         result.forEach(function (data) {
 
@@ -157,8 +157,8 @@
         cypherCallback = function (callback) {
 
             return function (response) {
-				if (response.errors.length > 0)
-					return callback(null, response.errors);
+                if (response.errors.length > 0)
+                    return callback(null, response.errors);
 
                 var graph = { nodes: [], edges: [] };
 

--- a/plugins/sigma.parsers.cypher/sigma.parsers.cypher.js
+++ b/plugins/sigma.parsers.cypher/sigma.parsers.cypher.js
@@ -68,8 +68,9 @@
             edgesMap = {},
             key;
 
+		if (typeof result === 'object') result = result.results[0].data;
         // Iteration on all result data
-        result.results[0].data.forEach(function (data) {
+        result.forEach(function (data) {
 
             // iteration on graph for all node
             data.graph.nodes.forEach(function (node) {
@@ -156,6 +157,8 @@
         cypherCallback = function (callback) {
 
             return function (response) {
+				if (response.errors.length > 0)
+					return callback(null, response.errors);
 
                 var graph = { nodes: [], edges: [] };
 

--- a/plugins/sigma.renderers.linkurious/README.md
+++ b/plugins/sigma.renderers.linkurious/README.md
@@ -16,6 +16,8 @@ This plugin overrides default renderers to provide more powerful renderers.Nodes
 - `icon`: *object*
 - `image`: *object*
 - `level`: *number*
+- 'border_size': *number*
+- 'border_color': *string*
 
 Edges take the following attributes:
 - `type`: *string*

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
@@ -81,6 +81,15 @@
     context.restore();
   };
 
+  var drawBorder = function(context, x, y, radius, color, line_width) {
+    context.beginPath();
+    context.strokeStyle = color;
+	context.lineWidth = line_width;
+    context.arc(x, y, radius, 0, Math.PI * 2, true);
+    context.closePath();
+    context.stroke();
+  };
+
   /**
    * The default node renderer. It renders the node as a simple disc.
    *
@@ -97,9 +106,12 @@
         y = node[prefix + 'y'],
         defaultNodeColor = settings('defaultNodeColor'),
         imgCrossOrigin = settings('imgCrossOrigin') || 'anonymous',
-        borderSize = settings('borderSize'),
+        borderSize = node.border_size || settings('borderSize'),
         outerBorderSize = settings('outerBorderSize'),
         color = o.color || node.color || defaultNodeColor,
+		borderColor = settings('nodeBorderColor') === 'node'
+          ? (o.borderColor || node.border_color || defaultNodeColor)
+          : settings('defaultNodeBorderColor'),
         level = node.active ? settings('nodeActiveLevel') : node.level;
 
     // Level:
@@ -157,9 +169,9 @@
       // Border:
       if (borderSize > 0) {
         context.beginPath();
-        context.fillStyle = settings('nodeBorderColor') === 'node' ?
-          (color || defaultNodeColor) :
-          settings('defaultNodeBorderColor');
+        context.fillStyle = settings('nodeBorderColor') === 'node'
+          ? borderColor
+          : settings('defaultNodeBorderColor');
         context.arc(x, y, size + borderSize, 0, Math.PI * 2, true);
         context.closePath();
         context.fill();
@@ -194,6 +206,10 @@
       context.arc(x, y, size, 0, Math.PI * 2, true);
       context.closePath();
       context.fill();
+
+      if (borderSize > 0) {
+		drawBorder(context, x, y, size, borderColor, borderSize);
+      }
     }
 
     // reset shadow

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
@@ -109,9 +109,9 @@
         borderSize = node.border_size || settings('borderSize'),
         outerBorderSize = settings('outerBorderSize'),
         color = o.color || node.color || defaultNodeColor,
-		borderColor = settings('nodeBorderColor') === 'node'
-          ? (o.borderColor || node.border_color || defaultNodeColor)
-          : settings('defaultNodeBorderColor'),
+		borderColor = settings('nodeBorderColor') === 'default'
+          ? settings('defaultNodeBorderColor')
+          : (node.border_color || o.borderColor || defaultNodeColor),
         level = node.active ? settings('nodeActiveLevel') : node.level;
 
     // Level:
@@ -207,7 +207,7 @@
       context.closePath();
       context.fill();
 
-      if (borderSize > 0) {
+      if (!node.active && borderSize > 0) {
 		drawBorder(context, x, y, size, borderColor, borderSize);
       }
     }

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.nodes.def.js
@@ -111,7 +111,7 @@
         color = o.color || node.color || defaultNodeColor,
 		borderColor = settings('nodeBorderColor') === 'default'
           ? settings('defaultNodeBorderColor')
-          : (node.border_color || o.borderColor || defaultNodeColor),
+          : (o.borderColor || node.border_color || defaultNodeColor),
         level = node.active ? settings('nodeActiveLevel') : node.level;
 
     // Level:


### PR DESCRIPTION
this patch enhances this renderer to paint a stroke of a user-defined
colour and width around the node