### PR TITLE
Remove width hack and clear canvas via clearRect

### DIFF
--- a/src/misc/sigma.misc.drawHovers.js
+++ b/src/misc/sigma.misc.drawHovers.js
@@ -29,10 +29,8 @@
     });
 
     function draw() {
-      // Clear self.contexts.hover:
-      self.contexts.hover.canvas.width = self.contexts.hover.canvas.width;
-
-      var embedSettings = self.settings.embedObjects({
+      var c = self.contexts.hover.canvas,
+          embedSettings = self.settings.embedObjects({
             prefix: prefix
           }),
           end = embedSettings('singleHover') ? 1 : undefined,
@@ -45,6 +43,8 @@
             graph: self.graph,
             settings: embedSettings,
           };
+
+      self.contexts.hover.clearRect(0, 0, c.width, c.height);
 
       // Node render
       if (current.nodes.length > 0 && embedSettings('enableHovering')) {

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -433,9 +433,9 @@
   sigma.renderers.canvas.prototype.clear = function() {
     var k;
 
-    for (k in this.domElements)
-      if (this.domElements[k].tagName === 'CANVAS')
-        this.domElements[k].width = this.domElements[k].width;
+    for (k in this.contexts) {
+      this.contexts[k].clearRect(0, 0, this.width, this.height);
+    }
 
     return this;
   };

--- a/src/renderers/sigma.renderers.webgl.js
+++ b/src/renderers/sigma.renderers.webgl.js
@@ -574,12 +574,7 @@
    * @return {sigma.renderers.webgl} Returns the instance itself.
    */
   sigma.renderers.webgl.prototype.clear = function() {
-    var k;
-
-    for (k in this.domElements)
-      if (this.domElements[k].tagName === 'CANVAS')
-        this.domElements[k].width = this.domElements[k].width;
-
+    this.contexts.labels.clearRect(0, 0, this.width, this.height);
     this.contexts.nodes.clear(this.contexts.nodes.COLOR_BUFFER_BIT);
     this.contexts.edges.clear(this.contexts.edges.COLOR_BUFFER_BIT);
 


### PR DESCRIPTION
Following #211 and https://github.com/jacomyal/sigma.js/commit/3397bd53bbec57606314810fbd77801c6269ef90

Via [jsperf.com](http://webcache.googleusercontent.com/search?q=cache:bUqXp7bT824J:jsperf.com/canvas-clearrect-vs-width/9+&cd=1&hl=fr&ct=clnk&gl=fr), we can see that clearRect is ~2 times faster.