### PR TITLE
Remove pre/post system for a more straightforward "infos" passing

### DIFF
--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dashed.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dashed.js
@@ -106,8 +106,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dotted.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.dotted.js
@@ -106,8 +106,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.parallel.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.parallel.js
@@ -119,8 +119,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.tapered.js
+++ b/plugins/sigma.renderers.customEdgeShapes/sigma.canvas.edgehovers.tapered.js
@@ -116,8 +116,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.def.js
+++ b/plugins/sigma.renderers.edgeLabels/sigma.canvas.edges.labels.def.js
@@ -7,22 +7,6 @@
   // Initialize packages:
   sigma.utils.pkg('sigma.canvas.edges.labels');
 
-  var PREV_FONT = null; //contains the current context.font value
-  //the ctx.font value is cached because accesing it is costly
-
-  sigma.canvas.edges.labels.def = {
-  /**
-   * This is executed before a render batch
-   * It just reset PREV_FONT
-   *
-   * @param  {CanvasRenderingContext2D} context      The canvas context.
-   * @param  {configurable}             settings     The settings function.
-   */
-    pre: function(context, settings) {
-      PREV_FONT = '';
-    },
-  };
-  
   /**
    * This label renderer will just display the label on the line of the edge.
    * The label is rendered at half distance of the edge extremities, and is
@@ -33,9 +17,10 @@
    * @param  {object}                   target node  The edge target node.
    * @param  {CanvasRenderingContext2D} context      The canvas context.
    * @param  {configurable}             settings     The settings function.
+   * @param  {object?}                  infos        The current batch infos.
    */
-  sigma.canvas.edges.labels.def.render =
-    function(edge, source, target, context, settings) {
+  sigma.canvas.edges.labels.def =
+    function(edge, source, target, context, settings, infos) {
     if (typeof edge.label !== 'string' || source == target)
       return;
 
@@ -84,9 +69,11 @@
       ].join(' ');
     }
 
-    if (PREV_FONT != new_font) { //use font value caching
+    if (infos && infos.ctx.font != new_font) { //use font value caching
       context.font = new_font;
-      PREV_FONT = new_font;
+      infos.ctx.font = new_font;
+    } else {
+      context.font = new_font;
     }
 
     context.textAlign = 'center';

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.arrow.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.arrow.js
@@ -120,8 +120,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels.arrow) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.arrow;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.arrow(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.curve.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.curve.js
@@ -108,8 +108,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels.curve) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.curve;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.curve(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.dashed.js
@@ -106,8 +106,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.def.js
@@ -101,8 +101,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels.def) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.parallel.js
@@ -119,8 +119,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.tapered.js
@@ -116,8 +116,7 @@
     // draw label with a background
     if (sigma.canvas.edges.labels) {
       edge.hover = true;
-      var def = sigma.canvas.edges.labels.def;
-      (def.render || def)(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.extremities.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.extremities.def.js
@@ -20,19 +20,15 @@
   sigma.canvas.extremities.def =
     function(edge, source, target, context, settings) {
     // Source Node:
-    var def = (
+    (
       sigma.canvas.hovers[source.type] ||
       sigma.canvas.hovers.def
-    );
-    def = def.render || def;
-    def(source, context, settings);
+    )(def(source, context, settings));
 
     // Target Node:
-    def = (
+    (
       sigma.canvas.hovers[target.type] ||
       sigma.canvas.hovers.def
-    );
-    def = def.render || def;
-    def(target, context, settings);
+    )(def(target, context, settings));
   };
 }).call(this);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -93,7 +93,6 @@
 
     // Node:
     var nodeRenderer = sigma.canvas.nodes[node.type] || sigma.canvas.nodes.def;
-    nodeRenderer = nodeRenderer.render || nodeRenderer;
     nodeRenderer(node, context, settings, { color: color });
 
     // reset shadow

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
@@ -7,31 +7,15 @@
   // Initialize packages:
   sigma.utils.pkg('sigma.canvas.labels');
 
-  var PREV_FONT = null; //contains the current context.font value
-  //the ctx.font value is cached because accesing it is costly
-
-  sigma.canvas.labels.def = {
-  /**
-   * This is executed before a render batch
-   * It just reset PREV_FONT
-   *
-   * @param  {CanvasRenderingContext2D} context      The canvas context.
-   * @param  {configurable}             settings     The settings function.
-   */
-    pre: function(context, settings) {
-      PREV_FONT = '';
-    },
-  };
-
   /**
    * This label renderer will display the label of the node
    *
    * @param  {object}                   node     The node object.
    * @param  {CanvasRenderingContext2D} context  The canvas context.
    * @param  {configurable}             settings The settings function.
+   * @param  {object?}                  infos    The batch infos.
    */
-  sigma.canvas.labels.def.render = 
-        function(node, context, settings) {
+  sigma.canvas.labels.def = function(node, context, settings, infos) {
     var fontSize,
         prefix = settings('prefix') || '',
         size = node[prefix + 'size'] || 1,
@@ -60,9 +44,11 @@
         settings('activeFont') || settings('font') :
         settings('font'));
 
-    if (PREV_FONT != new_font) { //use font value caching
+    if (infos && infos.ctx.font != new_font) { //use font value caching
       context.font = new_font;
-      PREV_FONT = new_font;
+      infos.ctx.font = new_font;
+    } else {
+      context.font = new_font;
     }
 
     if (node.active)

--- a/src/renderers/canvas/sigma.canvas.labels.def.js
+++ b/src/renderers/canvas/sigma.canvas.labels.def.js
@@ -7,31 +7,15 @@
   // Initialize packages:
   sigma.utils.pkg('sigma.canvas.labels');
 
-  var PREV_FONT = null; //contains the current context.font value
-  //the ctx.font value is cached because accesing it is costly
-
-  sigma.canvas.labels.def = {
-  /**
-   * This is executed before a render batch
-   * It just reset PREV_FONT
-   *
-   * @param  {CanvasRenderingContext2D} context      The canvas context.
-   * @param  {configurable}             settings     The settings function.
-   */
-    pre: function(context, settings) {
-      PREV_FONT = '';
-    },
-  };
-
   /**
    * This label renderer will display the label of the node
    *
    * @param  {object}                   node     The node object.
    * @param  {CanvasRenderingContext2D} context  The canvas context.
    * @param  {configurable}             settings The settings function.
+   * @param  {object?}                  infos    The batch infos.
    */
-  sigma.canvas.labels.def.render =
-        function(node, context, settings) {
+  sigma.canvas.labels.def = function(node, context, settings, infos) {
     var fontSize,
         prefix = settings('prefix') || '',
         size = node[prefix + 'size'] || 1,
@@ -58,9 +42,11 @@
         settings('activeFont') || settings('font') :
         settings('font'));
 
-    if (PREV_FONT != new_font) { //use font value caching
+    if (infos && infos.ctx.font != new_font) { //use font value caching
       context.font = new_font;
-      PREV_FONT = new_font;
+      infos.ctx.font = new_font;
+    } else {
+      context.font = new_font;
     }
 
     context.fillStyle =

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -27,8 +27,7 @@
     if (!(options.container instanceof HTMLElement))
       throw 'Container not found.';
 
-    var k,
-        i,
+    var i,
         l,
         a,
         fn,
@@ -120,7 +119,6 @@
    */
   sigma.renderers.canvas.applyRenderers = function(params) {
     var i,
-        k,
         renderer,
         specializedRenderer,
         def,
@@ -142,7 +140,6 @@
           els[i].type || params.settings(params.options, elementType)
         ];
         def = (specializedRenderer || params.renderers.def);
-        def = def.render || def;
         if (params.type == 'edges') {
           def(
             els[i],
@@ -425,11 +422,9 @@
    * @return {sigma.renderers.canvas} Returns the instance itself.
    */
   sigma.renderers.canvas.prototype.clear = function() {
-    var k;
-
-    for (k in this.domElements)
-      if (this.domElements[k].tagName === 'CANVAS')
-        this.domElements[k].width = this.domElements[k].width;
+    for (var k in this.contexts) {
+      this.contexts[k].clearRect(0, 0, this.width, this.height);
+    }
 
     return this;
   };

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -137,7 +137,7 @@
     for (i = params.start; i < params.end; i++) {
       if (!els[i].hidden) {
         specializedRenderer = params.renderers[
-          els[i].type || params.settings(params.options, elementType)
+          els[i].type || params.settings(elementType)
         ];
         def = (specializedRenderer || params.renderers.def);
         if (params.type == 'edges') {

--- a/src/renderers/sigma.renderers.canvas.js
+++ b/src/renderers/sigma.renderers.canvas.js
@@ -120,11 +120,13 @@
    */
   sigma.renderers.canvas.applyRenderers = function(params) {
     var i,
+        k,
         renderer,
         specializedRenderer,
         def,
         render,
         els = params.elements,
+        ctx_infos = {font: params.ctx.font},
         elementType = (params.elements || params.type == 'edges' ?
               'defaultEdgeType' : 'defaultNodeType');
 
@@ -134,38 +136,30 @@
 
     params.ctx.save();
 
-    for (renderer in params.renderers) {
-      if (params.renderers[renderer].pre) {
-        params.renderers[renderer].pre(params.ctx, params.settings);
-      }
-    }
     for (i = params.start; i < params.end; i++) {
       if (!els[i].hidden) {
         specializedRenderer = params.renderers[
           els[i].type || params.settings(params.options, elementType)
         ];
         def = (specializedRenderer || params.renderers.def);
-        render = (def.render || def);
+        def = def.render || def;
         if (params.type == 'edges') {
-          render(
+          def(
             els[i],
             params.graph.nodes(els[i].source),
             params.graph.nodes(els[i].target),
             params.ctx,
-            params.settings
+            params.settings,
+            {ctx: ctx_infos}
           );
         }else {
-          render(
+          def(
             els[i],
             params.ctx,
-            params.settings
+            params.settings,
+            {ctx: ctx_infos}
           );
         }
-      }
-    }
-    for (renderer in params.renderers) {
-      if (params.renderers[renderer].post) {
-        params.renderers[renderer].post(params.ctx, params.settings);
       }
     }
 
@@ -433,9 +427,9 @@
   sigma.renderers.canvas.prototype.clear = function() {
     var k;
 
-    for (k in this.contexts) {
-      this.contexts[k].clearRect(0, 0, this.width, this.height);
-    }
+    for (k in this.domElements)
+      if (this.domElements[k].tagName === 'CANVAS')
+        this.domElements[k].width = this.domElements[k].width;
 
     return this;
   };

--- a/src/renderers/sigma.renderers.svg.js
+++ b/src/renderers/sigma.renderers.svg.js
@@ -373,7 +373,7 @@
         hoveredNode = node;
       } else if (e.data.leave.nodes.length > 0) { // out
         node = e.data.leave.nodes[0];
-        
+
         // Deleting element
         self.domElements.groups.hovers.removeChild(
           self.domElements.hovers[node.id]


### PR DESCRIPTION
#169 solved it via pre/post but it was a solution with too many corner case and no backward-compatibility. This one focus on solving #168 but is extensible

* [x] add new system
* [x] remove pre/post system
* [x] remove ".render" occurences