### PR TITLE
Fix bugs when sigma was required with webpack

### DIFF
--- a/src/sigma.export.js
+++ b/src/sigma.export.js
@@ -6,10 +6,10 @@ sigma.conrad = conrad;
 
 // Dirty polyfills to permit sigma usage in node
 if (HTMLElement === undefined)
-  var HTMLElement = function() {};
+  HTMLElement = function() {};
 
 if (window === undefined)
-  var window = {
+  window = {
     addEventListener: function() {}
   };
 


### PR DESCRIPTION
The var declerations inside if statements were being hoisted,
resulting in HTMLElement and Window always being set to undefined.