### PR TITLE
Fix getTextWidth not being called correctly

### DIFF
--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -134,7 +134,7 @@
           labelOffsetY = - size - 2 * fontSize / 3;
           break;
         case 'inside':
-          labelWidth = getTextWidth(node.label);
+          labelWidth = sigma.utils.canvas.getTextWidth(node.label);
           if (labelWidth <= (size + fontSize / 3) * 2) {
             break;
           }


### PR DESCRIPTION
Setting the labelAllignment to "inside" caused a call to getTextWidth which didn't exist.