### PR TITLE
Add "constrained" labelAllignment setting

### DIFF
--- a/plugins/sigma.renderers.linkurious/README.md
+++ b/plugins/sigma.renderers.linkurious/README.md
@@ -344,6 +344,12 @@ To assign a shape renderer to an edge, simply set `edge.type='shape-name'` e.g. 
    * default value: `0`
    * available values: `0` (no shadow), `1` (low), `2`, `3`, `4`, `5` (high)
 
+ * **labelAlignment**
+   * Defines the positioning of labels relative to their nodes.
+   * type: *string*
+   * default value: `right`
+   * available values: `center`, `constrained`, `inside`, `right`, `left`, `top`, `bottom`
+
 You may override the default values when instantiating Sigma, e.g.:
 
 ````javascript

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -116,6 +116,7 @@
 
       var labelOffsetX = 0,
           labelOffsetY = fontSize / 3,
+          shouldRender = true,
           labelWidth;
       context.textAlign = "center";
 
@@ -132,6 +133,12 @@
         case 'top':
           labelOffsetY = - size - 2 * fontSize / 3;
           break;
+        case 'constrained':
+          labelWidth = sigma.utils.canvas.getTextWidth(node.label);
+          if (labelWidth > (size + fontSize / 3) * 2) {
+            shouldRender = false;
+          }
+          break;
         case 'inside':
           labelWidth = sigma.utils.canvas.getTextWidth(node.label);
           if (labelWidth <= (size + fontSize / 3) * 2) {
@@ -146,11 +153,13 @@
           break;
       }
 
-      context.fillText(
-        node.label,
-        Math.round(node[prefix + 'x'] + labelOffsetX),
-        Math.round(node[prefix + 'y'] + labelOffsetY)
-      );
+      if (shouldRender) {
+        context.fillText(
+          node.label,
+          Math.round(node[prefix + 'x'] + labelOffsetX),
+          Math.round(node[prefix + 'y'] + labelOffsetY)
+        );
+      }
     }
 
     function prepareLabelBackground(context) {

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.hovers.def.js
@@ -191,6 +191,8 @@
       if (node.label && typeof node.label === 'string') {
         // draw a rectangle for the label
         switch (alignment) {
+          case 'constrained':
+          /* falls through*/
           case 'center':
             y = Math.round(node[prefix + 'y'] - fontSize * 0.5 - 2);
             context.rect(x - w * 0.5, y, w, h);

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
@@ -29,7 +29,7 @@
         shouldRender = true,
         alignment = settings('labelAlignment');
 
-    if (size < settings('labelThreshold'))
+    if (size <= settings('labelThreshold'))
       return;
 
     if (!node.label || typeof node.label !== 'string')

--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.labels.def.js
@@ -26,9 +26,10 @@
         labelWidth,
         labelOffsetX,
         labelOffsetY,
+        shouldRender = true,
         alignment = settings('labelAlignment');
 
-    if (size <= settings('labelThreshold'))
+    if (size < settings('labelThreshold'))
       return;
 
     if (!node.label || typeof node.label !== 'string')
@@ -79,6 +80,13 @@
       case 'top':
         labelOffsetY = - size - 2 * fontSize / 3;
         break;
+      case 'constrained':
+        labelWidth = sigma.utils.canvas.getTextWidth(context,
+            settings('approximateLabelWidth'), fontSize, node.label);
+        if (labelWidth > (size + fontSize / 3) * 2) {
+          shouldRender = false;
+        }
+        break;
       case 'inside':
         labelWidth = sigma.utils.canvas.getTextWidth(context,
             settings('approximateLabelWidth'), fontSize, node.label);
@@ -94,10 +102,12 @@
         break;
     }
 
-    context.fillText(
-      node.label,
-      Math.round(node[prefix + 'x'] + labelOffsetX),
-      Math.round(node[prefix + 'y'] + labelOffsetY)
-    );
+    if (shouldRender) {
+      context.fillText(
+        node.label,
+        Math.round(node[prefix + 'x'] + labelOffsetX),
+        Math.round(node[prefix + 'y'] + labelOffsetY)
+      );
+    }
   };
 }).call(this);


### PR DESCRIPTION
The constrained labelAllignment setting is similar to center, but hides itself when it cannot fit within the bounds of the node, which leads to a more desirable behavior when zooming out.