### PR TITLE
Remove memory leak of sigma instances

### DIFF
--- a/src/sigma.core.js
+++ b/src/sigma.core.js
@@ -2,6 +2,16 @@
   'use strict';
 
   var __instances = {};
+  
+  // Deal with resize:
+  window.addEventListener('resize', function() {
+    for (var key in __instances) {
+      if (__instances.hasOwnProperty(key)) {
+        var graph = __instances[key];
+        graph.refresh();
+      }
+    }
+  });
 
   /**
    * This is the sigma instances constructor. One instance of sigma represent
@@ -74,8 +84,7 @@
 
     // Private attributes:
     // *******************
-    var _self = this,
-        _conf = conf || {};
+    var _conf = conf || {};
 
     // Little shortcut:
     // ****************
@@ -220,11 +229,6 @@
       this.refresh();
     }
 
-    // Deal with resize:
-    window.addEventListener('resize', function() {
-      if (_self.settings)
-        _self.refresh();
-    });
   };
 
 

--- a/src/sigma.core.js
+++ b/src/sigma.core.js
@@ -7,8 +7,8 @@
   window.addEventListener('resize', function() {
     for (var key in __instances) {
       if (__instances.hasOwnProperty(key)) {
-        var graph = __instances[key];
-        graph.refresh();
+        var instance = __instances[key];
+        instance.refresh();
       }
     }
   });


### PR DESCRIPTION
The window resize listener was leaking all of the sigma instances, even after they were killed.