### PR TITLE
node.js fixes

### DIFF
--- a/src/sigma.core.js
+++ b/src/sigma.core.js
@@ -3,15 +3,16 @@
 
   var __instances = {};
 
-  // Deal with resize:
-  window.addEventListener('resize', function() {
-    for (var key in __instances) {
-      if (__instances.hasOwnProperty(key)) {
-        var instance = __instances[key];
-        instance.refresh();
+  // Deal with resize.  skip this for node.js apps
+  if (typeof window != 'undefined')
+    window.addEventListener('resize', function() {
+      for (var key in __instances) {
+        if (__instances.hasOwnProperty(key)) {
+          var instance = __instances[key];
+          instance.refresh();
+        }
       }
-    }
-  });
+    });
 
   /**
    * This is the sigma instances constructor. One instance of sigma represent

--- a/src/sigma.export.js
+++ b/src/sigma.export.js
@@ -5,10 +5,10 @@ var sigma = this.sigma,
 sigma.conrad = conrad;
 
 // Dirty polyfills to permit sigma usage in node
-if (HTMLElement === undefined)
+if (typeof HTMLElement === 'undefined')
   HTMLElement = function() {};
 
-if (window === undefined)
+if (typeof window === 'undefined')
   window = {
     addEventListener: function() {}
   };


### PR DESCRIPTION
- github issue #362.  this avoids event installation for window resizes
in the node.js environment where `window` is not defined
- definition checks throw an exception when performed without the `typeof` operator