### PR TITLE
Insert glyphs canvas before mouse canvas

### DIFF
--- a/plugins/sigma.renderers.glyphs/sigma.renderers.glyphs.js
+++ b/plugins/sigma.renderers.glyphs/sigma.renderers.glyphs.js
@@ -55,7 +55,7 @@
       this.domElements['glyphs'].height = this.container.offsetHeight;
       this.container.insertBefore(
         this.domElements['glyphs'],
-        this.domElements['glyphs'].previousSibling
+        this.domElements['mouse']
       );
     }
     this.drawingContext = this.domElements['glyphs'].getContext('2d');


### PR DESCRIPTION
The last canvas in the HTML renderer may not always be the mouse canvas, (for example if the legends canvas is added before the glyphs render function is called).  If the glyphs canvas is placed after the mouse canvas, all mouse interactions break.  This places the glyph canvas before the mouse canvas regardless of where it was initially inserted in the stack.