### PR TITLE
Fixed non-download image creation.

### DIFF
--- a/plugins/sigma.exporters.image/sigma.exporters.image.js
+++ b/plugins/sigma.exporters.image/sigma.exporters.image.js
@@ -145,10 +145,11 @@
       s.settings('batchEdgesDrawing', false); // it may crash if true
     }
 
-    if(!params.clip)
-      this.clone(s, params, ratio);
+    if(!params.clip) {
+      clone(s, params, ratio);
+    }
 
-    var merged = this.draw(r, params, ratio);
+    var merged = draw(r, params, ratio);
 
     s.settings('batchEdgesDrawing', batchEdgesDrawing); // restore setting
 
@@ -168,7 +169,7 @@
   * @param {s}  sigma instance
   * @param {params}  Options
   */
-  Image.prototype.clone = function(s, params, ratio) {
+  function clone(s, params, ratio) {
     params.tmpContainer = params.tmpContainer || 'image-container';
 
     var pixelRatio = sigma.utils.getPixelRatio();
@@ -253,7 +254,7 @@
   * @param {renderer}  related renderer instance
   * @param {params}  Options
   */
-  Image.prototype.draw = function(r, params, ratio) {
+  function draw(r, params, ratio) {
     var webgl = r instanceof sigma.renderers.webgl,
         sized = false,
         doneContexts = [];
@@ -329,31 +330,11 @@
    * Interface
    * ------------------
    */
-  var _instance = null;
-
   /**
    * @param {sigma}  s       The related sigma instance.
    * @param {renderer}  r    The related renderer instance.
    * @param {object} options An object with options.
    */
-  sigma.plugins.image = function(s, r, options) {
-    sigma.plugins.killImage();
-    // Create object if undefined
-    if (!_instance) {
-      _instance = new Image(s, r, options);
-    }
-    return _instance;
-  };
-
-  /**
-   *  This function kills the image instance.
-   */
-  sigma.plugins.killImage = function() {
-    if (_instance instanceof Image) {
-      _instance = null;
-      _canvas = null;
-      _canvasContext = null;
-    }
-  };
-
+  sigma.plugins.image = Image;
+  sigma.plugins.image.bind(this);
 }).call(this);


### PR DESCRIPTION
The value for the image, 'dataUrl', was lost since the Image function was called with "new", which was a problem when using download: false.

In this PR I've replaced the instance management with a direct call to the Image function which then returns the dataUrl.