### PR TITLE
sigma.canvas.edges.labels.arrow does not exist

### DIFF
--- a/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.arrow.js
+++ b/plugins/sigma.renderers.linkurious/canvas/sigma.canvas.edgehovers.arrow.js
@@ -118,9 +118,9 @@
     }
 
     // draw label with a background
-    if (sigma.canvas.edges.labels && sigma.canvas.edges.labels.arrow) {
+    if (sigma.canvas.edges.labels && sigma.canvas.edges.labels.def) {
       edge.hover = true;
-      sigma.canvas.edges.labels.arrow(edge, source, target, context, settings);
+      sigma.canvas.edges.labels.def(edge, source, target, context, settings);
       edge.hover = false;
     }
   };


### PR DESCRIPTION
The labels are not shown when the mouse passes over the edge and the edges are rendered with the `arrow` type.

When `sigma.canvas.edges.labels.arrow` is substituted by `sigma.canvas.edges.labels.def`, the labels are shown again.