### PR TITLE
GEXF exporter: add parameter to ignore hidden nodes

### DIFF
--- a/plugins/sigma.exporters.gexf/README.md
+++ b/plugins/sigma.exporters.gexf/README.md
@@ -53,6 +53,9 @@ s.toGEXF({
  * **renderer**
    * The Sigma renderer. If provided, write the visualization attributes (position, size, color) of nodes and edges in the GEXF.
    * type: *sigma.renderers*
+ * **filterHidden**
+   * If true, the output in the GEXF will ignore hidden nodes and edges.
+   * type: *sigma.renderers*
  * **creator**
    * If provided, write the file creator in the META element of the GEXF.
    * type: *string*

--- a/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
+++ b/plugins/sigma.exporters.gexf/sigma.exporters.gexf.js
@@ -175,6 +175,12 @@
           params.renderer.camera.readPrefix;
       }
 
+      if (params.filterHidden) {
+        var filterFunction = function(x){return !x.hidden}
+        nodes = nodes.filter(filterFunction)
+        edges = edges.filter(filterFunction)
+      }
+
       var o,
           attrs,
           nodeAttrIndex = {},


### PR DESCRIPTION
Bonjour
This is a simple boolean option to be able to filter hidden nodes on export.
Integrate if it's useful for you.
We could also pass a custom filter function for more genericity.
Cordially
RL